### PR TITLE
Show event commentary to operator during event logging

### DIFF
--- a/django/RadioActiv8/admin.py
+++ b/django/RadioActiv8/admin.py
@@ -1,10 +1,10 @@
 import csv
 
+from simple_history.admin import SimpleHistoryAdmin
+
 from django.contrib.gis import admin
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from simple_history.admin import SimpleHistoryAdmin
-
 from RadioActiv8.forms import EventForm
 
 from .models import (
@@ -78,6 +78,7 @@ class ParticipantAdmin(SimpleHistoryAdmin):
 class PatrolAdmin(SimpleHistoryAdmin):
     search_fields = ("name",)
     list_filter = ("session",)
+
 
 class EventPatrolInline(admin.TabularInline):
     model = Intelligence

--- a/django/RadioActiv8/models.py
+++ b/django/RadioActiv8/models.py
@@ -1,6 +1,8 @@
 import random
 from datetime import timedelta
 
+from simple_history.models import HistoricalRecords
+
 from django.contrib import admin
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import Point
@@ -8,7 +10,6 @@ from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.db.models.constraints import UniqueConstraint
 from django.utils import timezone
-from simple_history.models import HistoricalRecords
 
 # FIXME: This default should be configurable
 DEFAULT_POINT = Point(144.63760, -36.49197)

--- a/django/RadioActiv8/static/RadioActiv8/js/event-form.js
+++ b/django/RadioActiv8/static/RadioActiv8/js/event-form.js
@@ -230,7 +230,7 @@ function dynamic_form_update(destination_toggle = false) {
 
       { // Display Base history, commentary and last expected destination
 
-        var base_history = '';
+        var base_history = (data.base_history.visited_bases.length == 0) ? '<li><em>Unknown</em></li>' : '';
         for (var i = 0; i < data.base_history.visited_bases.length; i++) {
           var id = data.base_history.visited_bases[i].id
           var name = data.base_history.visited_bases[i].name
@@ -238,7 +238,7 @@ function dynamic_form_update(destination_toggle = false) {
         }
         jQuery("#base_history").html(base_history);
 
-        var comment_history = '';
+        var comment_history = (data.comment_history.length == 0) ? '<li><em>None</em></li>' : '';
         for (var i = 0; i < data.comment_history.length; i++) {
           var timestamp = data.comment_history[i].timestamp
           var comment = data.comment_history[i].comment

--- a/django/RadioActiv8/static/RadioActiv8/js/event-form.js
+++ b/django/RadioActiv8/static/RadioActiv8/js/event-form.js
@@ -228,7 +228,7 @@ function dynamic_form_update(destination_toggle = false) {
         }
       }
 
-      { // Display Base history and last expected destination
+      { // Display Base history, commentary and last expected destination
 
         var base_history = '';
         for (var i = 0; i < data.base_history.visited_bases.length; i++) {
@@ -237,6 +237,14 @@ function dynamic_form_update(destination_toggle = false) {
           base_history += "<li data.base_history-base-id='" + id + "'>" + name + "</li>"
         }
         jQuery("#base_history").html(base_history);
+
+        var comment_history = '';
+        for (var i = 0; i < data.comment_history.length; i++) {
+          var timestamp = data.comment_history[i].timestamp
+          var comment = data.comment_history[i].comment
+          comment_history += "<li><em>" + timestamp + "</em><br/>" + comment + "</li>"
+        }
+        jQuery("#comment_history").html(comment_history);
 
         var expected_location = data.base_history.last_destination;
         if(!expected_location)

--- a/django/RadioActiv8/templates/RadioActiv8/event/create_form.html
+++ b/django/RadioActiv8/templates/RadioActiv8/event/create_form.html
@@ -33,10 +33,10 @@
             <input type="radio" name="check-in-out-toggle" id="radio-check-out">
             Check out
         </label>
-        <span class="destination_form_group" id="destination_form_group">
-            <p>{% bootstrap_field form.destination %}</p>
-        </span>
     </div>
+    <span class="destination_form_group" id="destination_form_group">
+        <p>{% bootstrap_field form.destination %}</p>
+    </span>
     <p>{% bootstrap_field form.comment %}</p>
     {{ form.media }}
     <input type="submit" value="Add Event" class="btn btn-warning m-3">

--- a/django/RadioActiv8/templates/RadioActiv8/master/map.html
+++ b/django/RadioActiv8/templates/RadioActiv8/master/map.html
@@ -257,9 +257,7 @@
                             <div class="collapse show" id="collapse-2">
                                 <div class="form-group">
                                     <!-- Start: Sort by "Longest Time since used" -->
-                                    <h1 class="text-monospace"
-                                        style="font-size: 12pt;
-                                               color: var(--white)">AVAILABLE BASES:</h1>
+                                    <h1 class="text-monospace" style="font-size: 12pt; color: var(--white)">AVAILABLE BASES:</h1>
                                     <!-- End: Sort by "Longest Time since used" -->
                                     <ul class="list-unstyled text-monospace">
                                         {% if available_bases %}
@@ -280,9 +278,7 @@
                                     </ul>
                                 </div>
                                 <div class="form-group">
-                                    <h1 class="text-monospace"
-                                        style="font-size: 12pt;
-                                               color: var(--white)">FULL BASES:</h1>
+                                    <h1 class="text-monospace" style="font-size: 12pt; color: var(--white)">FULL BASES:</h1>
                                     <ul class="list-unstyled text-monospace text-light">
                                         {% if full_bases %}
                                             {% for full_base in full_bases %}
@@ -302,9 +298,7 @@
                                 </div>
                                 <div class="form-group">
                                     <!-- Start: sort by "Last Updated" -->
-                                    <h1 class="text-monospace"
-                                        style="font-size: 12pt;
-                                               color: var(--white)">Patrol Locations:</h1>
+                                    <h1 class="text-monospace" style="font-size: 12pt; color: var(--white)">Patrol Locations:</h1>
                                     <!-- End: sort by "Last Updated" -->
                                     <ul class="list-unstyled text-monospace text-light">
                                         {% if busy_patrols %}

--- a/django/RadioActiv8/templates/RadioActiv8/master/play.html
+++ b/django/RadioActiv8/templates/RadioActiv8/master/play.html
@@ -30,7 +30,7 @@
                         <div class="col-md-6 col-lg-3 col-xl-3 offset-xl-0 text-monospace">
                             <strong>Base History:</strong>
                             <ol id="base_history">
-                                <li>Unknown</li>
+                                <li><em>Unknown</em></li>
                             </ol>
                             <strong>Commentary:</strong>
                             <ul id="comment_history">

--- a/django/RadioActiv8/templates/RadioActiv8/master/play.html
+++ b/django/RadioActiv8/templates/RadioActiv8/master/play.html
@@ -30,11 +30,15 @@
                         <div class="col-md-6 col-lg-3 col-xl-3 offset-xl-0 text-monospace">
                             <strong>Base History:</strong>
                             <ol id="base_history">
-                                <li><em>Unknown</em></li>
+                                <li>
+                                    <em>Unknown</em>
+                                </li>
                             </ol>
                             <strong>Commentary:</strong>
                             <ul id="comment_history">
-                                <li><em>None</em></li>
+                                <li>
+                                    <em>None</em>
+                                </li>
                             </ul>
                         </div>
                         {% comment %}

--- a/django/RadioActiv8/templates/RadioActiv8/master/play.html
+++ b/django/RadioActiv8/templates/RadioActiv8/master/play.html
@@ -32,6 +32,10 @@
                             <ol id="base_history">
                                 <li>Unknown</li>
                             </ol>
+                            <strong>Commentary:</strong>
+                            <ul id="comment_history">
+                                <li><em>None</em></li>
+                            </ul>
                         </div>
                         {% comment %}
                         <div class="col-md-2 col-xl-2 offset-xl-0 text-monospace">

--- a/django/RadioActiv8/templates/RadioActiv8/patrol/index.html
+++ b/django/RadioActiv8/templates/RadioActiv8/patrol/index.html
@@ -1,6 +1,8 @@
-{% extends 'RadioActiv8/master/heading.html' %}
+{% extends "RadioActiv8/master/heading.html" %}
 {% load bootstrap4 %}
-{% block bootstrap4_title %}RadioActiv8 - Patrols{% endblock %}
+{% block bootstrap4_title %}
+    RadioActiv8 - Patrols
+{% endblock bootstrap4_title %}
 {% block bootstrap4_content %}
     <div class="container">
         <div class="col m-3">
@@ -58,4 +60,4 @@
             </script>
         </div>
     </div>
-{% endblock %}
+{% endblock bootstrap4_content %}

--- a/django/RadioActiv8/urls.py
+++ b/django/RadioActiv8/urls.py
@@ -1,6 +1,7 @@
+from rest_framework import routers
+
 from django.contrib.auth import views as auth_views
 from django.urls import include, path
-from rest_framework import routers
 
 from . import api_views, views
 

--- a/django/RadioActiv8/views.py
+++ b/django/RadioActiv8/views.py
@@ -476,6 +476,7 @@ def event_ajax(request):
         session, patrol, current_location
     )
     response["base_history"] = patrol_base_history(session, patrol)
+    response["comment_history"] = patrol_comment_history(session, patrol)
 
     return JsonResponse(response, safe=False)
 
@@ -679,6 +680,20 @@ def valid_next_base_options(session, patrol, current_location):
 
     return response
 
+
+def patrol_comment_history(session, patrol):
+    events = (
+        Event.objects.filter(session=session)
+        .filter(patrol=patrol)
+        .order_by("-timestamp")
+    )
+    comment_list = [
+        {"timestamp": str(event.timestamp)[:-16], "comment": str(event.comment)}
+        for event in Event.objects.filter(session=session)
+        .filter(patrol=patrol)
+        .order_by("timestamp")
+    ]
+    return list(filter(lambda entry: entry["comment"] is not "", comment_list))
 
 def patrol_base_history(session, patrol):
     visited_bases = [

--- a/django/RadioActiv8/views.py
+++ b/django/RadioActiv8/views.py
@@ -690,6 +690,7 @@ def patrol_comment_history(session, patrol):
     ]
     return list(filter(lambda entry: entry["comment"] is not "", comment_list))
 
+
 def patrol_base_history(session, patrol):
     visited_bases = [
         {"id": event.location.id, "name": str(event.location)}

--- a/django/RadioActiv8/views.py
+++ b/django/RadioActiv8/views.py
@@ -686,7 +686,7 @@ def patrol_comment_history(session, patrol):
         {"timestamp": str(event.timestamp)[:-16], "comment": str(event.comment)}
         for event in Event.objects.filter(session=session)
         .filter(patrol=patrol)
-        .order_by("timestamp")
+        .order_by("-timestamp")
     ]
     return list(filter(lambda entry: entry["comment"] is not "", comment_list))
 

--- a/django/RadioActiv8/views.py
+++ b/django/RadioActiv8/views.py
@@ -682,11 +682,6 @@ def valid_next_base_options(session, patrol, current_location):
 
 
 def patrol_comment_history(session, patrol):
-    events = (
-        Event.objects.filter(session=session)
-        .filter(patrol=patrol)
-        .order_by("-timestamp")
-    )
     comment_list = [
         {"timestamp": str(event.timestamp)[:-16], "comment": str(event.comment)}
         for event in Event.objects.filter(session=session)

--- a/django/RadioActiv8/views.py
+++ b/django/RadioActiv8/views.py
@@ -688,7 +688,7 @@ def patrol_comment_history(session, patrol):
         .filter(patrol=patrol)
         .order_by("-timestamp")
     ]
-    return list(filter(lambda entry: entry["comment"] is not "", comment_list))
+    return list(filter(lambda entry: entry["comment"] != "", comment_list))
 
 
 def patrol_base_history(session, patrol):

--- a/django/myproject/settings.py
+++ b/django/myproject/settings.py
@@ -14,6 +14,7 @@ import email.utils
 from pathlib import Path
 
 import environ
+
 from django.conf.locale.en import formats as en_formats
 
 env = environ.Env(

--- a/django/scripts/event_to_csv.py
+++ b/django/scripts/event_to_csv.py
@@ -1,12 +1,12 @@
 # docker-compose exec app ./manage.py shell -c 'import event_to_csv'
 import csv
 
-from django.conf import settings
-from django.contrib.admin.models import LogEntry
-
 # activate(settings.TIME_ZONE)
 from pytz import timezone
 from RadioActiv8.models import Event
+
+from django.conf import settings
+from django.contrib.admin.models import LogEntry
 
 settings_time_zone = timezone(settings.TIME_ZONE)
 event_logs = LogEntry.objects.filter(


### PR DESCRIPTION
During an session there are situations where an operator may record some comments against an event that may either carry forward throughout the session, or something that you needs to be followed up on when they next check-in/out.  At present the operator would need to go out of the log event page back into the session event list to review (or keep paper notes).

This PR extends the Log Event UI to present any available commentary under the base history so it is available to support the needs of the operator sorted from most recent comment.